### PR TITLE
Tidy RBL list

### DIFF
--- a/godnsbl.go
+++ b/godnsbl.go
@@ -55,7 +55,6 @@ func Blacklists() []string {
 		"osrs.dnsbl.net.au",
 		"owfs.dnsbl.net.au",
 		"owps.dnsbl.net.au",
-		"pbl.spamhaus.org",
 		"phishing.rbl.msrbl.net",
 		"probes.dnsbl.net.au",
 		"proxy.bl.gweep.ca",
@@ -68,7 +67,6 @@ func Blacklists() []string {
 		"residential.block.transip.nl",
 		"ricn.dnsbl.net.au",
 		"rmst.dnsbl.net.au",
-		"sbl.spamhaus.org",
 		"short.rbl.jp",
 		"smtp.dnsbl.sorbs.net",
 		"socks.dnsbl.sorbs.net",
@@ -88,7 +86,6 @@ func Blacklists() []string {
 		"virus.rbl.msrbl.net",
 		"web.dnsbl.sorbs.net",
 		"wormrbl.imp.ch",
-		"xbl.spamhaus.org",
 		"zen.spamhaus.org",
 		"zombie.dnsbl.sorbs.net",
 	}

--- a/godnsbl.go
+++ b/godnsbl.go
@@ -88,6 +88,7 @@ func Blacklists() []string {
 		"wormrbl.imp.ch",
 		"zen.spamhaus.org",
 		"zombie.dnsbl.sorbs.net",
+		"cidr.bl.mcafee.com",
 	}
 }
 


### PR DESCRIPTION
Closes #4 

For now, all I've done is remove the redundant Spamhaus RBLs, and I've added `cidr.bl.mcafee.com`, which seems important.
I think that should be fine for now.