### PR TITLE
Pass context to DNS resolver

### DIFF
--- a/cmd/godnsbl/main.go
+++ b/cmd/godnsbl/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -22,7 +23,7 @@ func main() {
 	ip := os.Args[1]
 	rbl := os.Args[2]
 
-	result, err := godnsbl.Lookup(rbl, ip)
+	result, err := godnsbl.Lookup(context.Background(), rbl, ip)
 	if err != nil {
 		fmt.Println("Failed to lookup IP for RBL", err)
 		return


### PR DESCRIPTION
The package doesn't support context, but it really should..
I guess the default lookup function was created before context was...

So here we just pass a user-provided context down through the calls to the default resolver.